### PR TITLE
Focusability and role of links

### DIFF
--- a/js/Client.js
+++ b/js/Client.js
@@ -296,7 +296,7 @@ Client.prototype.drawItem = function (itemName, quantity) {
  * @param {int} action
  */
 Client.prototype.convertToLink = function(text, action) {
-    return "<a data-action='" + action + "' class='button'>" + text + "</a>";
+    return "<a data-action='" + action + "' class='button' tabindex='0' role='link'>" + text + "</a>";
 };
 
 /**


### PR DESCRIPTION
This pull request fixes two issues:

* Game links are not focused when pressed Tab/Shift+Tab.
* Game links do not have a link role (important for assistive technologies such as screen readers).
